### PR TITLE
Deprecate static and non-cache build

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@ VERSION=0.6.0
 
 DATA_DIR=data/
 IMAGE_OWNER=sertansenturk
+REPO_NAME=ds-template
 
 JUPYTER_SCIPY_IMAGE=scipy-notebook
 JUPYTER_SCIPY_VERSION=dc9744740e12

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.5.0
+VERSION=0.6.0
 
 DATA_DIR=data/
 IMAGE_OWNER=sertansenturk

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ jobs:
         - make test
       after_script:
         - ls -la ./data/ # mlflow artifact & tracking data
-    - name: "docker-compose-build-static"
-      if: branch IN (master, dev)
-      services: docker
-      script: make build-static
     - name: "Python 3.7"
       python: 3.7
       before_install:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Deprecate static Jupyter build
+
 ## v0.5.0
 
 - Add `scipy`, `tensorflow` and `pyspark` base image options from Jupyter docker stack

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Deprecate static Jupyter build
+- Deprecate static Jupyter and no-cache builds
 
 ## v0.5.0
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,7 @@ make clean-all
 make build
 ```
 
-This repo also includes a template Python package at [src/python_package](src/python_package), which is installed to the Jupyter docker image. By default, the package is "pip installed" in **editable** mode, and the **base folder is mounted** on the docker container. This way, the changes in the repo are synchronized.
-
-If you want to install the package statically, instead of `make build`, execute:
-
-```bash
-make build-static
-```
+This repo also includes a template Python package at [src/python_package](src/python_package), which is installed to the Jupyter docker image. By default, the package is "pip installed" in **editable** mode, and the **base folder is mounted** on the docker container. This way, the changes are synchronized.
 
 ## Run the Services
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         - MLFLOW_ARTIFACT_STORE=/${MLFLOW_ARTIFACT_STORE}
         - JUPYTER_BASE_IMAGE=${JUPYTER_BASE_IMAGE}
         - JUPYTER_BASE_VERSION=${JUPYTER_BASE_VERSION}
-    image: ${IMAGE_OWNER}/${JUPYTER_BASE_IMAGE}-${JUPYTER_TARGET}:${VERSION}
+    image: ${IMAGE_OWNER}/${REPO_NAME}/${JUPYTER_BASE_IMAGE}-${JUPYTER_TARGET}:${VERSION}
     ports:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     depends_on: 
@@ -30,7 +30,7 @@ services:
   mlflow:
     build:
       context: ./docker/mlflow
-    image: ${IMAGE_OWNER}/${MLFLOW_IMAGE_NAME}:${VERSION}
+    image: ${IMAGE_OWNER}/${REPO_NAME}/${MLFLOW_IMAGE_NAME}:${VERSION}
     expose: 
       - "${MLFLOW_TRACKING_SERVER_PORT}"
     ports:
@@ -52,7 +52,7 @@ services:
     user: "${POSTGRES_UID}:${POSTGRES_GID}"
     build:
       context: ./docker/postgres
-    image: ${IMAGE_OWNER}/${POSTGRES_IMAGE_NAME}:${VERSION}
+    image: ${IMAGE_OWNER}/${REPO_NAME}/${POSTGRES_IMAGE_NAME}:${VERSION}
     restart: always
     environment: 
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -58,12 +58,3 @@ COPY ./tests/docker ${TEST_DIR}/docker
 COPY ./docker/jupyter/scripts/run_pytest.sh ${TEST_DIR}/
 
 WORKDIR ${TEST_DIR}
-
-################## static image ###################
-FROM jupyter-custom AS static
-
-COPY ./src/ $WORK_DIR/src/
-COPY ./setup.py $WORK_DIR/
-
-WORKDIR $WORK_DIR
-RUN pip install .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Deprecate static Jupyter and no-cache builds

## Motivation and Context

We haven't used static and no-cache options. better to remove them for maintainability

## How Has This Been Tested?

There is no extra functionality involving code. We make some minor alterations to how the images are built. We ensure that these changes do not break anything by:

- Testing locally using `make test`
- Each commit is tested using travis.ci

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change: **deprecated functionalities**
- [ ] Documentation (extending or improving to describe the repo)

## Checklist

- [x] The code follows the code style of this project.
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
