### PR TITLE
Added cookiecutter dockerfile for default cutting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,10 @@
 
 ## v0.9.0
 
-- Added Sphinx documentation ([Pull Request #36](https://github.com/sertansenturk/cookiecutter-ds-docker/pull/36))
+- Add Sphinx documentation ([Pull Request #36](https://github.com/sertansenturk/cookiecutter-ds-docker/pull/36))
+- Create online documentation at [Read the Docs](https://readthedocs.org/projects/cookiecutter-ds-docker/)
+- Create Sphinx docker image and makefile recipes for local development
+- Change local cookiecutter processes from virtualenv to a Docker container
 - Add VERSION file to the base folder
 - Add LICENSE file to the base folder ([Pull Request #33](https://github.com/sertansenturk/cookiecutter-ds-docker/pull/33))
 - Add `step` parameter to the `mlflow.log_metrics` test case and jupyter demo

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Please refer to [Read The Docs](https://cookiecutter-ds-docker.readthedocs.io/en
 
 First, install [cookiecutter](https://cookiecutter.readthedocs.io/en/latest/installation.html#install-cookiecutter) and [docker](https://docs.docker.com/get-docker/).
 
-Then, run the commands below and follow the on-screen instructions to "bake" the template:
+Then, run the commands below and follow the on-screen instructions to "cut" a new project from the template:
 
 ```bash
 cd /[base_folder]
 cookiecutter gh:sertansenturk/cookiecutter-ds-docker
 ```
 
-To build and start the Docker stack in a baked project, run:
+To build and start the Docker stack, run:
 
 ```bash
 cd /[base_folder]/[repo_slug]

--- a/docker/cookiecutter/Dockerfile
+++ b/docker/cookiecutter/Dockerfile
@@ -1,11 +1,5 @@
 FROM python:3.7-slim
 
-# # install git; needed for pip if the template has git dependencies
-# RUN apt-get update && \
-#     apt-get install -y --no-install-recommends git && \
-#     apt-get purge -y --auto-remove && \
-#     rm -rf /var/lib/apt/lists/*
-
 RUN useradd -ms /bin/bash cookiecutteruser && \
     mkdir /project && \
     chown -R cookiecutteruser /project && \

--- a/docker/cookiecutter/Dockerfile
+++ b/docker/cookiecutter/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-slim
+
+# # install git; needed for pip if the template has git dependencies
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends git && \
+#     apt-get purge -y --auto-remove && \
+#     rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash cookiecutteruser && \
+    mkdir /project && \
+    chown -R cookiecutteruser /project && \
+    pip install cookiecutter
+
+USER cookiecutteruser
+WORKDIR /project
+
+ENTRYPOINT cookiecutter ./ --output-dir /project/tmp/ $CUT_OPTS

--- a/docker/cookiecutter/Dockerfile.dockerignore
+++ b/docker/cookiecutter/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# Ignore everything
+**

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==================================================
 
-To build and run the Docker stack in a baked project, simply run:
+To build and run the Docker stack in a cut project, simply run:
 
 .. code:: bash
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -31,10 +31,10 @@ Installing `cookiecutter` in Ubuntu and Mac OSX is straightforward:
 
 Please refer to the `official cookiecutter documentation <https://cookiecutter.readthedocs.io/en/latest/installation.html#install-cookiecutter>`_ for other options.
 
-Baking a New Project
+Cutting a New Project
 ---------------------------------------------------
 
-To "bake" a new project from the template, run:
+To "cut" a new project from the template, run:
 
 .. code:: bash
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,7 +1,7 @@
 Testing
 ==================================================
 
-You can test the cookiecutter, the baked services, and the installed Python package (e.g., build, unittest, code style, linting) locally by:
+You can test the cookiecutter, the docker-compose stack, and the installed Python package (e.g., build, unittest, code style, linting) locally by:
 
 .. code:: bash
 

--- a/{{ cookiecutter.repo_slug }}/README.md
+++ b/{{ cookiecutter.repo_slug }}/README.md
@@ -15,7 +15,7 @@
 
 ## 1. Introduction
 
-This project is "baked" from [sertansenturk/cookiecutter-ds-docker](https://github.com/sertansenturk/cookiecutter-ds-docker). It consists of a docker-compose stack with the services below (See Sections [Setup](#setup) and [Running the Services](#running-the-services)):
+This project is "cut" from [sertansenturk/cookiecutter-ds-docker](https://github.com/sertansenturk/cookiecutter-ds-docker). It consists of a docker-compose stack with the services below (See Sections [Setup](#setup) and [Running the Services](#running-the-services)):
 
 1. A [Jupyter](https://jupyter.org/) service with minimal customization
 2. An [mlflow](https://mlflow.org/) tracking server to store experiments


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Creates a cookiecutter docker file for local development

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So that we don't need to touch the local Python installation anymore

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- manually using `make test`
- in travis.ci

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (extending or improving to describe the repo)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code follows the code style of this project.
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
